### PR TITLE
Have "downloads" point to "latest"

### DIFF
--- a/downloads.html
+++ b/downloads.html
@@ -1,6 +1,6 @@
 <html>
 		<head>
-				<meta http-equiv="refresh" content="0; url=https://github.com/tvrenamer/tvrenamer/releases" />
+				<meta http-equiv="refresh" content="0; url=https://github.com/tvrenamer/tvrenamer/releases/latest" />
 		</head>
 </html>
 


### PR DESCRIPTION
Address Issue #2, downloads link should not show prereleases.

Prior to this commit, http://tvrenamer.org/downloads redirected to https://github.com/tvrenamer/tvrenamer/releases

This took the user to the page showing pre-releases.

This commit changes it to go to:
https://github.com/tvrenamer/tvrenamer/releases/latest

which only shows the latest actual release.

I'm not sure this is ideal. I think it would be nice to give them information about the various releases available -- maybe not redirect at all, but have a page on tvrenamer.org. But as a quick solution, this is better than going to the main releases page.